### PR TITLE
🔧 feat(agent/tools): add GitHubReviewTool for automated PR review requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,3 +94,6 @@ GEMINI_API_KEY=
 
 # MCP Configuration
 MCP_ENCRYPTION_KEY=your_32_byte_encryption_key_here
+
+# GitHub Integration
+GITHUB_PAT=your_github_personal_access_token

--- a/lib/agent/tools/github-review-tool.ts
+++ b/lib/agent/tools/github-review-tool.ts
@@ -1,0 +1,148 @@
+/**
+ * GitHub Review Tool for the AI Agent system.
+ *
+ * Detects GitHub PR links from conversation context and posts
+ * a review request comment (@gemini-cli /review) on each PR.
+ *
+ * Handles:
+ *  - Multiple PR links in a single message
+ *  - Deduplication of same PR
+ *  - Permission errors (401/403/404) with clear messages
+ *  - Missing GitHub token configuration
+ */
+
+import { Tool, ToolResult, AgentContext, ToolParameterSchema } from '../types';
+import { extractPRUrls, commentOnPR, ParsedPR } from '@/lib/github/github-api';
+
+const DEFAULT_REVIEW_COMMENT = '@gemini-cli /review';
+
+/**
+ * Parameter schema for the GitHub Review tool.
+ */
+const githubReviewParameterSchema: ToolParameterSchema = {
+  type: 'object',
+  properties: {
+    pr_urls: {
+      type: 'string',
+      description:
+        'Text containing one or more GitHub PR URLs (e.g. https://github.com/owner/repo/pull/123). If not provided, the tool will attempt to extract PR URLs from the conversation context.',
+    },
+    comment: {
+      type: 'string',
+      description:
+        'Custom comment to post on the PR. Defaults to "@gemini-cli /review".',
+    },
+  },
+  required: [],
+};
+
+/**
+ * GitHubReviewTool posts review request comments on GitHub PRs.
+ */
+export class GitHubReviewTool implements Tool {
+  name = 'github_review';
+  description =
+    'Post a code review request comment on GitHub Pull Requests. ' +
+    'Detects PR links from the message (e.g. https://github.com/owner/repo/pull/123) ' +
+    'and comments "@gemini-cli /review" on each PR. Supports multiple PR links at once.';
+  parameters = githubReviewParameterSchema;
+  cacheable = false;
+
+  /**
+   * Execute the GitHub Review tool.
+   *
+   * @param params - Tool parameters
+   * @param context - Agent context with conversation history
+   * @returns ToolResult with the operation results
+   */
+  async execute(
+    params: Record<string, unknown>,
+    context: AgentContext
+  ): Promise<ToolResult> {
+    // 1. Check for GitHub token
+    const token = process.env.GITHUB_PAT;
+    if (!token) {
+      return {
+        success: false,
+        error: 'GITHUB_PAT not configured',
+        displayText:
+          '❌ GitHub token not configured. Please set the `GITHUB_PAT` environment variable.',
+      };
+    }
+
+    // 2. Collect text sources to extract PR URLs from
+    const textSources: string[] = [];
+
+    // From explicit parameter
+    if (params.pr_urls && typeof params.pr_urls === 'string') {
+      textSources.push(params.pr_urls);
+    }
+
+    // From conversation history
+    if (context.conversationHistory && context.conversationHistory.length > 0) {
+      for (const msg of context.conversationHistory) {
+        textSources.push(msg.content);
+      }
+    }
+
+    // 3. Extract PR URLs
+    const allText = textSources.join('\n');
+    const prs: ParsedPR[] = extractPRUrls(allText);
+
+    if (prs.length === 0) {
+      return {
+        success: false,
+        error: 'No PR links found',
+        displayText:
+          '🔍 No GitHub PR links found in the conversation. Please share a PR link like `https://github.com/owner/repo/pull/123`.',
+      };
+    }
+
+    // 4. Determine comment content
+    const comment =
+      typeof params.comment === 'string' && params.comment.trim()
+        ? params.comment.trim()
+        : DEFAULT_REVIEW_COMMENT;
+
+    // 5. Post comments on all PRs
+    const results = await Promise.all(
+      prs.map((pr) => commentOnPR(pr, comment, token))
+    );
+
+    // 6. Build response
+    const succeeded = results.filter((r) => r.success);
+    const failed = results.filter((r) => !r.success);
+
+    const lines: string[] = [];
+
+    if (succeeded.length > 0) {
+      lines.push(`✅ Successfully commented on ${succeeded.length} PR(s):`);
+      for (const r of succeeded) {
+        lines.push(`  • ${r.prUrl} → [comment](${r.commentUrl})`);
+      }
+    }
+
+    if (failed.length > 0) {
+      if (lines.length > 0) lines.push('');
+      lines.push(`❌ Failed on ${failed.length} PR(s):`);
+      for (const r of failed) {
+        lines.push(`  • ${r.prUrl} — ${r.error}`);
+      }
+    }
+
+    const displayText = lines.join('\n');
+
+    return {
+      success: failed.length === 0,
+      data: { succeeded, failed, comment },
+      displayText,
+    };
+  }
+}
+
+/**
+ * Factory function to create a GitHubReviewTool instance.
+ */
+export function createGitHubReviewTool(): GitHubReviewTool {
+  return new GitHubReviewTool();
+}

--- a/lib/agent/tools/index.ts
+++ b/lib/agent/tools/index.ts
@@ -9,6 +9,7 @@ import { JiraSummaryTool, createJiraSummaryTool } from './jira-summary-tool';
 import { AppointmentTool, createAppointmentTool } from './appointment-tool';
 import { CITool, createCITool } from './ci-tool';
 import { QATool, createQATool } from './qa-tool';
+import { GitHubReviewTool, createGitHubReviewTool } from './github-review-tool';
 
 // Re-export tools and factory functions
 export { JiraTool, createJiraTool };
@@ -16,6 +17,7 @@ export { JiraSummaryTool, createJiraSummaryTool };
 export { AppointmentTool, createAppointmentTool };
 export { CITool, createCITool };
 export { QATool, createQATool };
+export { GitHubReviewTool, createGitHubReviewTool };
 
 // Re-export types for convenience
 export type { Tool, ToolResult, AgentContext } from '../types';
@@ -32,6 +34,7 @@ export function createAllTools() {
     createAppointmentTool(),
     // createCITool(),
     createQATool(),
+    createGitHubReviewTool(),
   ];
 }
 
@@ -46,5 +49,6 @@ export function getAvailableToolNames(): string[] {
     'lookup_appointment',
     'manage_ci_subscription',
     'ask_question',
+    'github_review',
   ];
 }

--- a/lib/github/github-api.ts
+++ b/lib/github/github-api.ts
@@ -1,0 +1,153 @@
+/**
+ * GitHub API Client
+ *
+ * Provides methods to interact with the GitHub API.
+ * Uses a Personal Access Token (PAT) for authentication.
+ */
+
+import axios, { AxiosError } from 'axios';
+import { logger } from '../utils/logger';
+
+const GITHUB_API_BASE = 'https://api.github.com';
+
+/**
+ * Result of a GitHub API operation.
+ */
+export interface GitHubOperationResult {
+  success: boolean;
+  prUrl: string;
+  owner: string;
+  repo: string;
+  prNumber: number;
+  error?: string;
+  commentUrl?: string;
+}
+
+/**
+ * Parsed GitHub PR info from a URL.
+ */
+export interface ParsedPR {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  originalUrl: string;
+}
+
+/**
+ * Extract all GitHub PR URLs from a text string.
+ * Supports formats:
+ *   - https://github.com/owner/repo/pull/123
+ *   - http://github.com/owner/repo/pull/123
+ *   - github.com/owner/repo/pull/123
+ *
+ * @param text - Text to extract PR URLs from
+ * @returns Array of parsed PR info
+ */
+export function extractPRUrls(text: string): ParsedPR[] {
+  const prRegex = /(?:https?:\/\/)?github\.com\/([a-zA-Z0-9\-_.]+)\/([a-zA-Z0-9\-_.]+)\/pull\/(\d+)/g;
+  const results: ParsedPR[] = [];
+  const seen = new Set<string>();
+
+  let match;
+  while ((match = prRegex.exec(text)) !== null) {
+    const key = `${match[1]}/${match[2]}/${match[3]}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      results.push({
+        owner: match[1],
+        repo: match[2],
+        prNumber: parseInt(match[3], 10),
+        originalUrl: match[0],
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Post a comment on a GitHub Pull Request.
+ *
+ * @param pr - Parsed PR info
+ * @param comment - Comment body to post
+ * @param token - GitHub Personal Access Token
+ * @returns Operation result
+ */
+export async function commentOnPR(
+  pr: ParsedPR,
+  comment: string,
+  token: string
+): Promise<GitHubOperationResult> {
+  const { owner, repo, prNumber, originalUrl } = pr;
+  const url = `${GITHUB_API_BASE}/repos/${owner}/${repo}/issues/${prNumber}/comments`;
+
+  try {
+    const response = await axios.post(
+      url,
+      { body: comment },
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'User-Agent': 'GengarBark-Bot',
+        },
+        timeout: 10000,
+      }
+    );
+
+    logger.info(`Successfully commented on PR ${originalUrl}`, {
+      owner,
+      repo,
+      prNumber,
+      commentId: response.data.id,
+    });
+
+    return {
+      success: true,
+      prUrl: originalUrl,
+      owner,
+      repo,
+      prNumber,
+      commentUrl: response.data.html_url,
+    };
+  } catch (error) {
+    const axiosError = error as AxiosError<{ message?: string }>;
+    const status = axiosError.response?.status;
+    const message = axiosError.response?.data?.message || axiosError.message;
+
+    let errorMessage: string;
+    switch (status) {
+      case 401:
+        errorMessage = 'GitHub token is invalid or expired. Please update GITHUB_PAT.';
+        break;
+      case 403:
+        errorMessage = `No permission to comment on ${owner}/${repo}#${prNumber}. The token may lack 'repo' scope or you don't have access to this repository.`;
+        break;
+      case 404:
+        errorMessage = `PR not found: ${owner}/${repo}#${prNumber}. The repository may be private or the PR doesn't exist.`;
+        break;
+      case 422:
+        errorMessage = `Invalid request for ${owner}/${repo}#${prNumber}: ${message}`;
+        break;
+      default:
+        errorMessage = `Failed to comment on ${owner}/${repo}#${prNumber}: ${status ? `HTTP ${status} - ` : ''}${message}`;
+    }
+
+    logger.error(`Failed to comment on PR ${originalUrl}`, {
+      owner,
+      repo,
+      prNumber,
+      status,
+      error: errorMessage,
+    });
+
+    return {
+      success: false,
+      prUrl: originalUrl,
+      owner,
+      repo,
+      prNumber,
+      error: errorMessage,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Add a new Agent tool `github_review` that automatically posts review request comments on GitHub PRs.

## What it does

When a user asks Gengar to review code and shares PR link(s), the tool:

1. **Extracts PR URLs** from conversation context (supports multiple links)
2. **Deduplicates** same PR links
3. **Posts comment** `@gemini-cli /review` on each PR using configured GitHub PAT
4. **Reports results** — success with comment links, or clear error messages

## Error Handling

| Case | Behavior |
|------|----------|
| No `GITHUB_PAT` configured | Clear error message asking to set env var |
| No PR links found | Prompts user to share a PR link |
| 401 Unauthorized | Token invalid/expired message |
| 403 Forbidden | No permission / missing repo scope |
| 404 Not Found | PR doesn't exist or private repo |
| Multiple PRs | Processes all, reports per-PR results |

## Files Changed

- `lib/github/github-api.ts` — GitHub API client (extract PR URLs, post comments)
- `lib/agent/tools/github-review-tool.ts` — Agent tool implementation
- `lib/agent/tools/index.ts` — Register new tool in createAllTools()
- `.env.example` — Added `GITHUB_PAT`

## Usage

In Slack, mention Gengar with a PR link:

> @Gengar help me review https://github.com/sakiila/gengar-bark-next/pull/42

Gengar will comment `@gemini-cli /review` on the PR.

## Setup

Add `GITHUB_PAT` to your environment variables with a token that has `repo` scope.